### PR TITLE
Fix tiled authentication

### DIFF
--- a/data_validation.py
+++ b/data_validation.py
@@ -6,7 +6,7 @@ from tiled.client import from_profile
 @task(retries=2, retry_delay_seconds=10)
 def read_all_streams(uid, beamline_acronym):
     logger = get_run_logger()
-    tiled_client = from_profile("nsls2", username=None)
+    tiled_client = from_profile("nsls2")
     run = tiled_client[beamline_acronym]["raw"][uid]
     logger.info(f"Validating uid {run.start['uid']}")
     start_time = ttime.monotonic()

--- a/export.py
+++ b/export.py
@@ -12,7 +12,7 @@ from prefect import task, flow, get_run_logger
 
 @task
 def run_export_fxi(uid):
-    tiled_client = databroker.from_profile("nsls2", username=None)["fxi"]["raw"]
+    tiled_client = databroker.from_profile("nsls2")["fxi"]["raw"]
     scan_id = tiled_client[uid].start["scan_id"]
     scan_type = tiled_client[uid].start["plan_name"]
     logger = get_run_logger()


### PR DESCRIPTION
Specifying `username=None` in `from_profile` caused tiled to error out because both a tiled API key and username are provided.